### PR TITLE
add regex unmatched handling

### DIFF
--- a/main.go
+++ b/main.go
@@ -89,6 +89,10 @@ func handleMessage(api *slack.Client, ev *slack.MessageEvent) {
 	}
 
 	matched := cmdRegex.FindStringSubmatch(ev.Text)
+	if len(matched) == 0 {
+		fmt.Printf("Unknown command")
+		return
+	}
 	fmt.Println(matched)
 	switch matched[1] {
 	case "tip":


### PR DESCRIPTION
I found that this bot will die if text is not matched Regex such as `@tiperc20 ping`. Because matched doesn't have any elements. I've added a error handling for that.

Produced error is as follows under go 1.9.
```
$ go run main.go token.go -port 20020
[]
panic: runtime error: index out of range

goroutine 1 [running]:
main.handleMessage(0xc420098580, 0xc4201f2200)
        /home/finc/.gvm/pkgsets/go1.9/global/src/tiperc20/main.go:93 +0x2b8
main.main()
        /home/finc/.gvm/pkgsets/go1.9/global/src/tiperc20/main.go:71 +0x43d
exit status 2
```